### PR TITLE
Enhancement: Implement `Expression\Assignment` as a value object

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,10 +12,12 @@ For a full diff see [`7039e81...main`][7039e81...main].
 
 - Implemented `Expression\Name` as a value object ([#1]), by [@localheinz]
 - Implemented `Expression\Value` as a value object ([#2]), by [@localheinz]
+- Implemented `Expression\Assignment` as a value object ([#3]), by [@localheinz]
 
 [7039e81...main]: https://github.com/ergebnis/twig-front-matter/compare/7039e81...main
 
 [#1]: https://github.com/ergebnis/twig-front-matter/pull/1
 [#2]: https://github.com/ergebnis/twig-front-matter/pull/2
+[#3]: https://github.com/ergebnis/twig-front-matter/pull/3
 
 [@localheinz]: https://github.com/localheinz

--- a/src/Expression/Assignment.php
+++ b/src/Expression/Assignment.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright (c) 2023 Andreas Möller
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE.md file that was distributed with this source code.
+ *
+ * @see https://github.com/ergebnis/twig-front-matter
+ */
+
+namespace Ergebnis\Twig\FrontMatter\Expression;
+
+/**
+ * @see https://twig.symfony.com/doc/3.x/tags/set.html
+ */
+final class Assignment
+{
+    private function __construct(
+        private readonly Name $name,
+        private readonly Value $value,
+        private readonly bool $force,
+    ) {
+    }
+
+    public static function create(
+        Name $name,
+        Value $value,
+        bool $force,
+    ): self {
+        return new self(
+            $name,
+            $value,
+            $force,
+        );
+    }
+
+    public function toString(): string
+    {
+        $name = $this->name->toString();
+        $value = $this->value->toString();
+
+        if ($this->force) {
+            return <<<TWIG
+{% set {$name} = {$value} %}
+TWIG;
+        }
+
+        if ($this->value->isMergeable()) {
+            return <<<TWIG
+{% set {$name} = {$name} is defined ? {$name}|merge({$value}) : {$value} %}
+TWIG;
+        }
+
+        return <<<TWIG
+{% set {$name} = {$name} is defined ? {$name} : {$value} %}
+TWIG;
+    }
+}

--- a/test/Unit/Expression/AssignmentTest.php
+++ b/test/Unit/Expression/AssignmentTest.php
@@ -1,0 +1,114 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright (c) 2023 Andreas Möller
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE.md file that was distributed with this source code.
+ *
+ * @see https://github.com/ergebnis/twig-front-matter
+ */
+
+namespace Ergebnis\Twig\FrontMatter\Test\Unit\Expression;
+
+use Ergebnis\Twig\FrontMatter\Expression;
+use Ergebnis\Twig\FrontMatter\Test;
+use PHPUnit\Framework;
+
+#[Framework\Attributes\CoversClass(Expression\Assignment::class)]
+#[Framework\Attributes\UsesClass(Expression\Name::class)]
+#[Framework\Attributes\UsesClass(Expression\Value::class)]
+final class AssignmentTest extends Framework\TestCase
+{
+    use Test\Util\Helper;
+
+    public function testCreateReturnsAssignmentWhenForceIsTrueAndValueIsMergeable(): void
+    {
+        $faker = self::faker();
+
+        $name = Expression\Name::fromString($faker->word());
+        $value = Expression\Value::fromRaw([
+            'words' => $faker->words(),
+            'dateTime' => $faker->dateTime(),
+            'bool' => $faker->boolean(),
+        ]);
+
+        $assignment = Expression\Assignment::create(
+            $name,
+            $value,
+            true,
+        );
+
+        $expected = <<<TWIG
+{% set {$name->toString()} = {$value->toString()} %}
+TWIG;
+
+        self::assertSame($expected, $assignment->toString());
+    }
+
+    public function testCreateReturnsAssignmentWhenForceIsTrueAndValueIsNotMergeable(): void
+    {
+        $faker = self::faker();
+
+        $name = Expression\Name::fromString($faker->word());
+        $value = Expression\Value::fromRaw($faker->sentence());
+
+        $assignment = Expression\Assignment::create(
+            $name,
+            $value,
+            true,
+        );
+
+        $expected = <<<TWIG
+{% set {$name->toString()} = {$value->toString()} %}
+TWIG;
+
+        self::assertSame($expected, $assignment->toString());
+    }
+
+    public function testCreateReturnsAssignmentWhenForceIsFalseAndValueIsMergeable(): void
+    {
+        $faker = self::faker();
+
+        $name = Expression\Name::fromString($faker->word());
+        $value = Expression\Value::fromRaw([
+            'words' => $faker->words(),
+            'dateTime' => $faker->dateTime(),
+            'bool' => $faker->boolean(),
+        ]);
+
+        $assignment = Expression\Assignment::create(
+            $name,
+            $value,
+            false,
+        );
+
+        $expected = <<<TWIG
+{% set {$name->toString()} = {$name->toString()} is defined ? {$name->toString()}|merge({$value->toString()}) : {$value->toString()} %}
+TWIG;
+
+        self::assertSame($expected, $assignment->toString());
+    }
+
+    public function testCreateReturnsAssignmentWhenForceIsFalseAndValueIsNotMergeable(): void
+    {
+        $faker = self::faker();
+
+        $name = Expression\Name::fromString($faker->word());
+        $value = Expression\Value::fromRaw($faker->sentence());
+
+        $assignment = Expression\Assignment::create(
+            $name,
+            $value,
+            false,
+        );
+
+        $expected = <<<TWIG
+{% set {$name->toString()} = {$name->toString()} is defined ? {$name->toString()} : {$value->toString()} %}
+TWIG;
+
+        self::assertSame($expected, $assignment->toString());
+    }
+}


### PR DESCRIPTION
This pull request

- [x] implements `Expression\Assignment` as a value object