### PR TITLE
Fix: Allow installation of `twig/twig:^3.4.3`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 For a full diff see [`1.0.0...main`][1.0.0...main].
 
+### Changed
+
+- Allowed installation of `twig/twig:^3.4.3` ([#8]), by [@localheinz]
+
 ## [`1.0.0`][1.0.0]
 
 For a full diff see [`7039e81...1.0.0`][7039e81...1.0.0].
@@ -34,5 +38,6 @@ For a full diff see [`7039e81...1.0.0`][7039e81...1.0.0].
 [#5]: https://github.com/ergebnis/twig-front-matter/pull/5
 [#6]: https://github.com/ergebnis/twig-front-matter/pull/6
 [#7]: https://github.com/ergebnis/twig-front-matter/pull/7
+[#8]: https://github.com/ergebnis/twig-front-matter/pull/8
 
 [@localheinz]: https://github.com/localheinz

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
   "require": {
     "php": "~8.1.0 || ~8.2.0",
     "ergebnis/front-matter": "^3.0.0",
-    "twig/twig": "^3.6.1"
+    "twig/twig": "^3.4.3"
   },
   "require-dev": {
     "ergebnis/composer-normalize": "^2.32.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "16febde77195c9f1e5a0ca1203c4ff24",
+    "content-hash": "8c55e4665a8571f637722f004e6b8dfa",
     "packages": [
         {
             "name": "ergebnis/front-matter",


### PR DESCRIPTION
This pull request

- [x] allows installation of `twig/twig:^3.4.3`