### PR TITLE
Fix: Do not configure `platform`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -54,9 +54,6 @@
     "audit": {
       "abandoned": "report"
     },
-    "platform": {
-      "php": "8.1.0"
-    },
     "preferred-install": "dist",
     "sort-packages": true
   },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "a62e42b6c25230b6c68cb73a33a1da7d",
+    "content-hash": "b80a45ef0e891095d9209750abfd51e3",
     "packages": [
         {
             "name": "ergebnis/front-matter",
@@ -6547,8 +6547,5 @@
         "php": "~8.1.0 || ~8.2.0 || ~8.3.0"
     },
     "platform-dev": [],
-    "platform-overrides": {
-        "php": "8.1.0"
-    },
     "plugin-api-version": "2.6.0"
 }


### PR DESCRIPTION
This pull request

- [x] stops configuring the [`platform`](https://getcomposer.org/doc/06-config.md#platform) in `composer.json`

Follows https://github.com/ergebnis/php-package-template/pull/1376.